### PR TITLE
chore: modernize Terraform and provider versions

### DIFF
--- a/infrastructure/terraform/versions.tf
+++ b/infrastructure/terraform/versions.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.7.0, < 5.0"
+      version = "~> 3.116"
     }
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
## Summary
Tighten azurerm constraint to prevent v4.

### Changes
- azurerm `>= 3.7.0, < 5.0` → `~> 3.116`
- TF version already at `>= 1.9.2` — unchanged

Closes #1